### PR TITLE
Improve installation on Ubuntu

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,13 @@ maintainer_email 'support+chef@signalfx.com'
 license 'Copyright SignalFx, Inc. All rights reserved'
 description 'This cookbook provides a set of recipes to install and cofigure the collectd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'
 
 supports "centos"
 supports "amazon"
 supports "ubuntu"
+
+depends "apt"
 
 recipe "chef_install_configure_collectd::default",
   "Install the lastest version collectd of SignalFx, Inc"

--- a/recipes/config-write_http.rb
+++ b/recipes/config-write_http.rb
@@ -28,6 +28,7 @@ end
 
 template "/etc/collectd.d/managed_config/10-aggregation-cpu.conf" do
   source "10-aggregation-cpu.conf.erb"
+  notifies :restart, "service[collectd]"
 end
 
 ingesturl = node["write_http"]["Ingest_host"]
@@ -42,8 +43,10 @@ template "/etc/collectd.d/managed_config/10-write_http-plugin.conf" do
     :INGEST_HOST => ingesturl, 
     :API_TOKEN => node["write_http"]["API_TOKEN"]
   })
+  notifies :restart, "service[collectd]"
 end
 
 service 'collectd' do
-  action [:enable, :stop, :start]
+  supports enable: true, start: true, stop: true
+  action [ :enable, :start ]
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,6 @@
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 
 def install_in_redhat( os, version )
-
   if node["SignalFx_rpm_repo"][os].include? version
     signalfx_package = node["SignalFx_rpm_repo"][os][version]["SignalFx-repo"]
     signalfx_package_link = node["SignalFx_rpm_repo"][os][version]["SignalFx-repo-link"]
@@ -24,39 +23,17 @@ def install_in_redhat( os, version )
               "collectd-disk",
               "collectd-write_http"
             ]
-
-  end
-
-end
-
-def ubuntu_update()
-  execute "apt_update" do
-    command "apt-get update"
-    action :run
   end
 end
-
-def install_in_ubuntu()
-  ubuntu_update()
-  package "software-properties-common"
-  package "python-software-properties"
-  execute "add-ppa" do
-    command "add-apt-repository ppa:signalfx/collectd-release"
-    action :run
-  end
-  ubuntu_update()
-  package "collectd"
-end
-
 
 case node[:platform]
-  when "centos"
-# Get the centos integer version
-    install_in_redhat("centos", node["platform_version"].to_i.to_s)
-  when "amazon"
-    install_in_redhat("amazon", node["platform_version"])
-  when "ubuntu"
-    install_in_ubuntu()
-  else
-    puts "We do not support your system"
+when "centos"
+  # Get the centos integer version
+  install_in_redhat("centos", node["platform_version"].to_i.to_s)
+when "amazon"
+  install_in_redhat("amazon", node["platform_version"])
+when "ubuntu"
+  include_recipe "chef_install_configure_collectd::ubuntu_install"
+else
+  puts "We do not support your system"
 end

--- a/recipes/ubuntu_install.rb
+++ b/recipes/ubuntu_install.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: collectd_install_configure
+# Recipe:: ubuntu_install
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+package "software-properties-common"
+package "python-software-properties"
+
+apt_repository "signalfx-collectd" do
+  uri          "ppa:signalfx/collectd-release"
+  distribution node["lsb"]["codename"]
+  keyserver    "keyserver.ubuntu.com"
+  key          "FE128AB0"
+end
+
+package "collectd"
+


### PR DESCRIPTION
I noticed that collectd is getting restarted on every chef-client run, and the ubuntu installation didn't take advantage of the apt community cookbook, so it was running apt-get update every single chef run.

* use apt cookbook on Ubuntu (will trigger apt-get update according to attributes, default once per day)
* Don't restart collectd every chef run, notify restart on config file change

We run chef on a 30-minute loop, so our /var/log/collectd.log looked like:
```
2015-10-05 10:51:22] Exiting normally.
[2015-10-05 10:51:22] collectd: Stopping 5 read threads.
[2015-10-05 10:51:22] collectd: Stopping 5 write threads.
[2015-10-05 10:51:23] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 10:51:23] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 10:51:23] cpufreq plugin: Found 0 CPUs
[2015-10-05 10:51:23] Initialization complete, entering read-loop.
[2015-10-05 11:22:40] Exiting normally.
[2015-10-05 11:22:40] collectd: Stopping 5 read threads.
[2015-10-05 11:22:40] collectd: Stopping 5 write threads.
[2015-10-05 11:22:41] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 11:22:41] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 11:22:41] cpufreq plugin: Found 0 CPUs
[2015-10-05 11:22:41] Initialization complete, entering read-loop.
[2015-10-05 11:53:57] Exiting normally.
[2015-10-05 11:53:57] collectd: Stopping 5 read threads.
[2015-10-05 11:53:57] collectd: Stopping 5 write threads.
[2015-10-05 11:53:58] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 11:53:58] write_http plugin: Legacy <URL> block found. Please use <Node> instead.
[2015-10-05 11:53:58] cpufreq plugin: Found 0 CPUs
[2015-10-05 11:53:58] Initialization complete, entering read-loop.
```